### PR TITLE
Removed console.log

### DIFF
--- a/SafariExtension/Resources/page_performance.js
+++ b/SafariExtension/Resources/page_performance.js
@@ -35,8 +35,6 @@ var PageInfo = (function(window, document) {
 			pageLatency = unfixedLatency.toFixed(2); 
 		}
 
-		console.log('Sending latency from page_performance', pageLatency, host+pathname);
-
 		safari.extension.dispatchMessage('recordPageInfo', {
 			domain: `${protocol}//${host}${pathname}`,
 			latency: pageLatency


### PR DESCRIPTION
Extension is currently logging on all pages, everywhere, regardless of if the site is whitelisted.
I've submitted feedback based on this already but here's a PR for the fix.

Log statement is unnecessary for a production build.
